### PR TITLE
Update Saab 9-5 generations: Added Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Saab 9-5
 
+This repository contains signal set configurations for the Saab 9-5, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Saab 9-5.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Saab_9-5"
+
 generations:
   - name: "First Generation"
     start_year: 1997


### PR DESCRIPTION
- Cross-referenced with Wikipedia article for accuracy
- First Generation (1997-2010): GM2900 platform, sedan and wagon variants
- Second Generation (2010-2012): Epsilon II platform, production ended March 2011
- Added references array to generations.yaml per standard format
- Updated README.md with standard template
